### PR TITLE
Add documentation of custom vocabulary API endpoint

### DIFF
--- a/docs/modules/customvocab.md
+++ b/docs/modules/customvocab.md
@@ -64,3 +64,11 @@ In this image, the Resource Template modified earlier is loaded for a new item. 
 This image shows the dropdown open, displaying the values from the "US states & territories" vocabulary.
 
 ![as described](../modules/modulesfiles/customVocab_item2.png)
+
+## Accessing custom vocab through the API
+
+If you are a developer trying to access the custom vocabulary list through the API, the end points are the following: 
+
+- List of custom vocabularies are at `/api/custom_vocabs`
+- The details of a specific custom vocabulary is at `/api/custom_vocabs/<id>`
+


### PR DESCRIPTION
It's a question that I had and ended up spending too much time digging through the PHP code to find it. There's [a question](https://forum.omeka.org/t/how-do-you-use-custom-vocabs-in-the-api/11108) in the forum about it, and it's unanswered. I thought other developers might find it useful!

I thought of adding the documentation to the developer docs, but those don't have a section that is dedicated to the REST APIs of the modules. 